### PR TITLE
Remove duplicate default_register initialization in YRPaste

### DIFF
--- a/plugin/yankring.vim
+++ b/plugin/yankring.vim
@@ -1368,7 +1368,6 @@ function! s:YRPaste(replace_last_paste_selection, nextvalue, direction, ...)
 
     let user_register  = s:YRRegister()
     let default_register = ((&clipboard=~'\<unnamed\>')?'*':((&clipboard=~'\<unnamedplus\>' && has('unnamedplus'))?'+':'"'))
-    let default_register = '"'
     let clipboard_default = matchstr( &clipboard, '\<unnamed\w*\>' )
     if has('unnamedplus') && clipboard_default == '\<unnamedplus\>' &&  (v:register == '' || v:register == '"')
         let default_register = '+'


### PR DESCRIPTION
After v15.0 released,  I encountered the message "YR: A register cannot be specified in replace mode" after I paste yanked string from history. This bases on that `default_register` is initialized twice in YRPaste.
This commit fixes the issue.
