### PR TITLE
Use nnoremap for @.

### DIFF
--- a/plugin/yankring.vim
+++ b/plugin/yankring.vim
@@ -1716,7 +1716,7 @@ function! s:YRMapsCreate(...)
     endif
 
     " silent! nmap <expr> @ YRMapsExpression("<SID>", "@", "1")
-    silent! nmap @ :<C-U>YRMapsMacro<CR>
+    silent! nnoremap @ :<C-U>YRMapsMacro<CR>
 
     let s:yr_maps_created_zap = 1
 


### PR DESCRIPTION
In my vimrc, I remap `;` and `:` ( I swapped them).

In such case, we need use nore mapping to make the mapping work.
