### PR TITLE
use TextYankRing autocmd instead of hacking mappings when possible

### DIFF
--- a/plugin/yankring.vim
+++ b/plugin/yankring.vim
@@ -2872,8 +2872,17 @@ if has("menu") && g:yankring_default_menu_mode != 0
 endif
 
 if g:yankring_enabled == 1
-    " Create YankRing Maps
-    call s:YRMapsCreate()
+  if !exists('##TextYankPost')
+      " Create YankRing Maps
+      call s:YRMapsCreate()
+  else
+      augroup YankRing
+          au! TextYankPost * call s:YRMRUAdd( 's:yr_history_list'
+                      \ , getreg(v:event.regname)
+                      \ , getregtype(v:event.regname)
+                      \ )
+      augroup END
+  endif
 endif
 
 call s:YRInit()


### PR DESCRIPTION
Vim8 and NeoVim have `TextYankRing` autocmd now. With this feature, we can easily get register type and register content when something puts into it, without hacking mappings.