### PR TITLE
Make yankring history hidden by default.

### DIFF
--- a/plugin/yankring.vim
+++ b/plugin/yankring.vim
@@ -47,7 +47,7 @@ if !exists('g:yankring_buffer_name')
 endif
 
 if !exists('g:yankring_history_file')
-    let g:yankring_history_file = 'yankring_history'
+    let g:yankring_history_file = '.yankring_history'
 endif
 
 " Allow the user to override the # of yanks/deletes recorded


### PR DESCRIPTION
Make yankring history hidden by default.  Currently it creates a file called yankring_history_v2.txt in your home folder, which a lot of people don't particularly want (https://stackoverflow.com/questions/15010271/change-location-of-vim-yankring-history-file/15010272#15010272).